### PR TITLE
Remove sudo and dist tags from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
-dist: trusty
 cache: pip
-sudo: required
 
 before_install:
   - sudo apt-get install shellcheck


### PR DESCRIPTION
Remove 'sudo: required' and 'dist: trusty' from the .travis.yml
file.  Both are depricated.

Fixes #16